### PR TITLE
Exclude groups, Pattern list creation & parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Test coverage
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+test:
+	go test -v ./...
+
+lint:
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run -v
+
+coverage:
+	go clean -testcache && go test -coverprofile=coverage/coverage.out ./... && go tool cover -html=coverage/coverage.out -o=coverage/coverage.html
+
+
+.PHONY: test lint coverage

--- a/ignore.go
+++ b/ignore.go
@@ -1,5 +1,10 @@
 package ignore
 
+import (
+	"os"
+	"path/filepath"
+)
+
 type Bits = uint8
 
 const (
@@ -27,3 +32,43 @@ type IgnorePattern struct {
 	Pattern         string
 	OriginalPattern string
 }
+
+func NewIgnorer(absPath string) (*Ignorer, error) {
+	ig := &Ignorer{}
+
+	ignorePath := filepath.Join(absPath, ".gitignore")
+	excludePath := filepath.Join(absPath, ".git", "info", "exclude")
+
+	if err := ig.AppendExcludeGroup(ignorePath, ".gitignore"); err != nil {
+		return nil, err
+	}
+
+	if err := ig.AppendExcludeGroup(excludePath, "exclude"); err != nil {
+		return nil, err
+	}
+
+	return ig, nil
+}
+
+func NewExcludeGroup(path, src string) (*ExcludeGroup, error) {
+	group := &ExcludeGroup{Src: src, BasePath: filepath.Clean(path)}
+
+	iFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer iFile.Close()
+	return group, nil
+}
+
+func (ig *Ignorer) AppendExcludeGroup(path, src string) error {
+	group, err := NewExcludeGroup(path, src)
+	if err != nil {
+		return err
+	}
+
+	ig.ExcludeGroups = append(ig.ExcludeGroups, *group)
+	return nil
+}
+

--- a/ignore.go
+++ b/ignore.go
@@ -80,6 +80,13 @@ func ScanPatterns(r io.Reader) ([]IgnorePattern, error) {
 	iPatterns := make([]IgnorePattern, 0, 10)
 	scanner := bufio.NewScanner(r)
 
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+	}
 
 	return iPatterns, scanner.Err()
 }

--- a/ignore.go
+++ b/ignore.go
@@ -86,12 +86,19 @@ func ScanPatterns(r io.Reader) ([]IgnorePattern, error) {
 			continue
 		}
 
+		line = bytes.TrimFunc(line, unicode.IsSpace)
+		iPattern := NewIgnorePattern(line)
+		iPatterns = append(iPatterns, iPattern)
 	}
 
 	return iPatterns, scanner.Err()
 }
 
 func NewIgnorePattern(line []byte) IgnorePattern {
-	return IgnorePattern{}
+	return parsePattern(line)
 }
 
+func parsePattern(line []byte) IgnorePattern {
+	iPattern := IgnorePattern{OriginalPattern: string(line)}
+	return iPattern
+}

--- a/ignore.go
+++ b/ignore.go
@@ -1,8 +1,12 @@
 package ignore
 
 import (
+	"bufio"
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
+	"unicode"
 )
 
 type Bits = uint8
@@ -70,5 +74,17 @@ func (ig *Ignorer) AppendExcludeGroup(path, src string) error {
 
 	ig.ExcludeGroups = append(ig.ExcludeGroups, *group)
 	return nil
+}
+
+func ScanPatterns(r io.Reader) ([]IgnorePattern, error) {
+	iPatterns := make([]IgnorePattern, 0, 10)
+	scanner := bufio.NewScanner(r)
+
+
+	return iPatterns, scanner.Err()
+}
+
+func NewIgnorePattern(line []byte) IgnorePattern {
+	return IgnorePattern{}
 }
 

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -9,6 +9,14 @@ import (
 	ignore "github.com/AntoninoAdornetto/go-gitignore"
 )
 
+/*
+testdata/.gitignore - contains the patterns used for test cases
+testdata/results.json - contains the expected results we should get after parsing each pattern
+
+If additional tests need to be added, see the bit flags in ignore.go for how to calculate the
+decimal value. It's pretty straight forward but wanted to mention it just in case
+*/
+
 func TestScanPatterns(t *testing.T) {
 	ig := ignore.Ignorer{}
 	err := ig.AppendExcludeGroup("./testdata/.gitignore", ".gitignore")
@@ -19,6 +27,8 @@ func TestScanPatterns(t *testing.T) {
 
 	for i, expected := range expectedResults.Results {
 		original := expected.Original
+		formatted := expected.Formatted
+		flags := expected.Flags
 		actual := actualResults.PatternList[i]
 
 		if original != actual.OriginalPattern {
@@ -29,6 +39,14 @@ func TestScanPatterns(t *testing.T) {
 			)
 		}
 
+		if formatted != actual.Pattern {
+			t.Fatalf("expected formatted pattern to be %s but got %s", formatted, actual.Pattern)
+		}
+
+		// heads up, the flags in json have to be converted from binary to decmial.
+		if flags != actual.Flags {
+			t.Fatalf("expected flags for %s to be %d but got %d", formatted, flags, actual.Flags)
+		}
 	}
 }
 
@@ -144,6 +162,7 @@ type results struct {
 type resultList struct {
 	Original  string `json:"original-pattern"`
 	Formatted string `json:"formatted-pattern"`
+	Flags     uint8  `json:"flags"`
 }
 
 func readResultData(t *testing.T) results {

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -61,7 +61,7 @@ func TestNewIgnorer(t *testing.T) {
 	}
 
 	// attempt to create a new ignorer with a bad path
-	ig, err = ignore.NewIgnorer("./testdata/unknowndir")
+	_, err = ignore.NewIgnorer("./testdata/unknowndir")
 	if err == nil {
 		t.Log("expected an error but got nil")
 		t.FailNow()
@@ -180,5 +180,9 @@ func readResultData(t *testing.T) results {
 
 	results := results{}
 	err = json.Unmarshal(data, &results)
+	if err != nil {
+		t.Fatalf("expected unmarshal error to be nil but got %s", err.Error())
+	}
+
 	return results
 }

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -1,0 +1,112 @@
+package ignore_test
+
+import (
+	"testing"
+
+	ignore "github.com/AntoninoAdornetto/go-gitignore"
+)
+
+func TestNewIgnorer(t *testing.T) {
+	ig, err := ignore.NewIgnorer("./")
+	assertIgnorer(t, ig, err)
+
+	// creates 2 exclude groups. 1 for the root .gitignore file and 1 for the .git/info/exclude file
+	groups := ig.ExcludeGroups
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 exclude groups but got %d", len(groups))
+	}
+
+	// attempt to create a new ignorer with a bad path
+	ig, err = ignore.NewIgnorer("./testdata/unknowndir")
+	if err == nil {
+		t.Log("expected an error but got nil")
+		t.FailNow()
+	}
+}
+
+func TestNewExcludeGroup(t *testing.T) {
+	// .gitignore exclude group
+	group, err := ignore.NewExcludeGroup("./.gitignore", ".gitignore")
+	assertExcludeGroup(t, group, err)
+
+	// .git/info/exclude exclude group
+	group, err = ignore.NewExcludeGroup("./.git/info/exclude", "exclude")
+	assertExcludeGroup(t, group, err)
+
+	// error when path does not contain a .gitignore or exclude file
+	group, err = ignore.NewExcludeGroup("./testdata/unknownpath", ".gitignore")
+	if err == nil {
+		t.Log("expected to receive an error but got nil")
+		t.FailNow()
+	}
+
+	if group != nil {
+		t.Log("expected exclude group to be nil")
+		t.FailNow()
+	}
+
+	group, err = ignore.NewExcludeGroup("./testdata/unknownpath", "exclude")
+	if err == nil {
+		t.Log("expected to receive an error but got nil")
+		t.FailNow()
+	}
+
+	if group != nil {
+		t.Log("expected exclude group to be nil")
+		t.FailNow()
+	}
+}
+
+func TestAppendExcludeGroup(t *testing.T) {
+	ig := ignore.Ignorer{}
+
+	err := ig.AppendExcludeGroup("./.gitignore", ".gitignore")
+	if err != nil {
+		t.Fatalf("expected append error to be nil but got %s", err.Error())
+	}
+
+	if len(ig.ExcludeGroups) != 1 {
+		t.Fatalf("expected exclude groups to have length of 1 but got %d", len(ig.ExcludeGroups))
+	}
+
+	err = ig.AppendExcludeGroup("./.git/info/exclude", "exclude")
+	if err != nil {
+		t.Fatalf("expected append error to be nil but got %s", err.Error())
+	}
+
+	if len(ig.ExcludeGroups) != 2 {
+		t.Fatalf("expected exclude groups to have length of 2 but got %d", len(ig.ExcludeGroups))
+	}
+
+	err = ig.AppendExcludeGroup("./unknown.gitignore", ".gitignore")
+	if err == nil {
+		t.Log("expected an err but got nil")
+		t.FailNow()
+	}
+
+	if len(ig.ExcludeGroups) != 2 {
+		t.Fatalf("expected exclude groups to have length of 2 but got %d", len(ig.ExcludeGroups))
+	}
+}
+
+func assertIgnorer(t *testing.T, ig *ignore.Ignorer, err error) {
+	if err != nil {
+		t.Fatalf("expected ignorer instantiation to not return and error but got %s", err.Error())
+	}
+
+	if ig == nil {
+		t.Log("expected ignorer struct not to be nill")
+		t.FailNow()
+	}
+}
+
+func assertExcludeGroup(t *testing.T, exc *ignore.ExcludeGroup, err error) {
+	if err != nil {
+		t.Fatalf("expected exclude group instantiation to not return an error but got %s", err)
+	}
+
+	if exc == nil {
+		t.Log("expected exclude group not to be nill")
+		t.FailNow()
+	}
+}

--- a/testdata/.gitignore
+++ b/testdata/.gitignore
@@ -1,5 +1,6 @@
 # Optional Prefix, negate the pattern
 !important.txt
+!important!.txt
 
 # Directory Separator
 doc/frotz/

--- a/testdata/.gitignore
+++ b/testdata/.gitignore
@@ -1,0 +1,34 @@
+# Optional Prefix, negate the pattern
+!important.txt
+
+# Directory Separator
+doc/frotz/
+frotz/
+foo/bar/baz
+
+# Asterisk
+*.log
+
+# Leading consecutive asterisks
+# Matches file or directory foo anywhere, same as pattern foo
+**/foo
+# matches file or directory "bar" anywhere that is directly under dir "foo"
+**/foo/bar
+
+# Trailing consecutive asterisks
+# Matches all files inside directory abc, relative to the location of .gitignore
+abc/**
+
+# Separator followed by consecutive asterisks
+# Matches zero or more directories. matches a/b, a/x/b, a/x/y/b
+a/**/b
+
+# Character matcher. Matches any one character except /
+fuz?.txt
+
+# Range notation, match characters in a range
+buz[a-z]lightyear.txt
+
+# Mix of above patterns
+backup/modules/ignore/*.log
+backup/modules/[a-z]gnore/fo[a-z].txt

--- a/testdata/results.json
+++ b/testdata/results.json
@@ -1,0 +1,56 @@
+{
+  "results": [
+    {
+      "original-pattern": "!important.txt",
+      "formatted-pattern": "important.txt"
+    },
+    {
+      "original-pattern": "doc/frotz/",
+      "formatted-pattern": "doc/frotz"
+    },
+    {
+      "original-pattern": "frotz/",
+      "formatted-pattern": "frotz"
+    },
+    {
+      "original-pattern": "foo/bar/baz",
+      "formatted-pattern": "foo/bar/baz"
+    },
+    {
+      "original-pattern": "*.log",
+      "formatted-pattern": "*.log"
+    },
+    {
+      "original-pattern": "**/foo",
+      "formatted-pattern": "*/foo"
+    },
+    {
+      "original-pattern": "**/foo/bar",
+      "formatted-pattern": "*/foo/bar"
+    },
+    {
+      "original-pattern": "abc/**",
+      "formatted-pattern": "abc/*"
+    },
+    {
+      "original-pattern": "a/**/b",
+      "formatted-pattern": "a/*/b"
+    },
+    {
+      "original-pattern": "fuz?.txt",
+      "formatted-pattern": "fuz?.txt"
+    },
+    {
+      "original-pattern": "buz[a-z]lightyear.txt",
+      "formatted-pattern": "buz[a-z]lightyear.txt"
+    },
+    {
+      "original-pattern": "backup/modules/ignore/*.log",
+      "formatted-pattern": "backup/modules/ignore/*.log"
+    },
+    {
+      "original-pattern": "backup/modules/[a-z]gnore/fo[a-z].txt",
+      "formatted-pattern": "backup/modules/[a-z]gnore/fo[a-z].txt"
+    }
+  ]
+}

--- a/testdata/results.json
+++ b/testdata/results.json
@@ -2,55 +2,73 @@
   "results": [
     {
       "original-pattern": "!important.txt",
-      "formatted-pattern": "important.txt"
+      "formatted-pattern": "important.txt",
+      "flags": 33
+    },
+    {
+      "original-pattern": "!important!.txt",
+      "formatted-pattern": "important!.txt",
+      "flags": 33
     },
     {
       "original-pattern": "doc/frotz/",
-      "formatted-pattern": "doc/frotz"
+      "formatted-pattern": "doc/frotz",
+      "flags": 2
     },
     {
       "original-pattern": "frotz/",
-      "formatted-pattern": "frotz"
+      "formatted-pattern": "frotz",
+      "flags": 2
     },
     {
       "original-pattern": "foo/bar/baz",
-      "formatted-pattern": "foo/bar/baz"
+      "formatted-pattern": "foo/bar/baz",
+      "flags": 0
     },
     {
       "original-pattern": "*.log",
-      "formatted-pattern": "*.log"
+      "formatted-pattern": "*.log",
+      "flags": 5
     },
     {
       "original-pattern": "**/foo",
-      "formatted-pattern": "*/foo"
+      "formatted-pattern": "*/foo",
+      "flags": 4
     },
     {
       "original-pattern": "**/foo/bar",
-      "formatted-pattern": "*/foo/bar"
+      "formatted-pattern": "*/foo/bar",
+      "flags": 4
     },
     {
       "original-pattern": "abc/**",
-      "formatted-pattern": "abc/*"
+      "formatted-pattern": "abc/*",
+      "flags": 4
     },
     {
       "original-pattern": "a/**/b",
-      "formatted-pattern": "a/*/b"
+      "formatted-pattern": "a/*/b",
+      "flags": 4
     },
     {
       "original-pattern": "fuz?.txt",
-      "formatted-pattern": "fuz?.txt"
+      "formatted-pattern": "fuz?.txt",
+      "flags": 9
     },
     {
       "original-pattern": "buz[a-z]lightyear.txt",
-      "formatted-pattern": "buz[a-z]lightyear.txt"
+      "formatted-pattern": "buz[a-z]lightyear.txt",
+      "flags": 17
     },
     {
       "original-pattern": "backup/modules/ignore/*.log",
-      "formatted-pattern": "backup/modules/ignore/*.log"
+      "formatted-pattern": "backup/modules/ignore/*.log",
+      "flags": 4
     },
     {
       "original-pattern": "backup/modules/[a-z]gnore/fo[a-z].txt",
-      "formatted-pattern": "backup/modules/[a-z]gnore/fo[a-z].txt"
+      "formatted-pattern": "backup/modules/[a-z]gnore/fo[a-z].txt",
+      "flags": 16
     }
   ]
 }


### PR DESCRIPTION
- Create exclude group for `.gitignore` file. **supports nested .gitignore files**
- Create exclude group for `.git/info/exclude` file
- parse patterns based on git specifications 
- build meta data of each pattern via bit flags 
- test the hell outta everything 